### PR TITLE
Create *basic* search API

### DIFF
--- a/server.js
+++ b/server.js
@@ -4,6 +4,8 @@ const fs = require('fs');
 const read = fs.readFileSync;
 const app = express();
 
+const SearchService = require('./server/services/search-service');
+
 app.use(express.static('views'));
 app.use('/dist', express.static('dist'));
 
@@ -13,7 +15,11 @@ app.get('/', (req, res) => {
 
 // TODO: implement search across users and interests
 app.get('/search', (req, res) => {
-  res.send({});
+  SearchService.search(req.query.q, (err, users) => {
+    if (err) return console.error(err);
+
+    res.send(users);
+  });
 });
 
 const server = app.listen(process.env.PORT || 5000, () => {

--- a/server/collections/index.js
+++ b/server/collections/index.js
@@ -1,0 +1,9 @@
+const mongoose = require('mongoose');
+
+// TODO: centralize this connection and export to a config var
+mongoose.connect('mongodb://localhost/adoptahudlie');
+
+module.exports = {
+  InterestCollection: require('./interest-collection'),
+  UserCollection: require('./user-collection'),
+};

--- a/server/collections/interest-collection.js
+++ b/server/collections/interest-collection.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const mongoose = require('mongoose');
-const Interest = require('../models/interest');
+const Interest = require('../models/interest').Interest;
 
 class InterestCollection {
   static getInterests(cb) {

--- a/server/collections/interest-collection.js
+++ b/server/collections/interest-collection.js
@@ -1,16 +1,11 @@
 'use strict';
 
 const mongoose = require('mongoose');
-const Interest = require('../models/interest').Interest;
+const Interest = require('../models/interest');
 
 class InterestCollection {
-  static getInterests(cb) {
-    // TODO: centralize this connection and export to a config var
-    mongoose.connect('mongodb://localhost/adoptahudlie');
-
-    mongoose.connection.once('open', () => {
-      Interest.find(cb);
-    });
+  static getInterests(query, cb) {
+    Interest.find(query, cb);
   }
 }
 

--- a/server/collections/user-collection.js
+++ b/server/collections/user-collection.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const mongoose = require('mongoose');
+const User = require('../models/user');
+
+class UserCollection {
+  static getUsers(query, cb) {
+    User.find(query, cb);
+  }
+}
+
+module.exports = UserCollection;

--- a/server/models/interest.js
+++ b/server/models/interest.js
@@ -12,7 +12,4 @@ const InterestSchema = Schema({
 
 const Interest = mongoose.model('Interest', InterestSchema);
 
-module.exports = {
-  InterestSchema: InterestSchema,
-  Interest: Interest,
-};
+module.exports = Interest;

--- a/server/models/interest.js
+++ b/server/models/interest.js
@@ -4,10 +4,15 @@ const Schema = mongoose.Schema;
 const InterestSchema = Schema({
   _id: Schema.Types.ObjectId,
   name: String,
-  ranking: Number,
-  availability: Boolean,
+  keywords: [{
+    userId: Schema.Types.ObjectId,
+    term: String,
+  }],
 });
 
 const Interest = mongoose.model('Interest', InterestSchema);
 
-module.exports = Interest;
+module.exports = {
+  InterestSchema: InterestSchema,
+  Interest: Interest,
+};

--- a/server/models/mentor-status.js
+++ b/server/models/mentor-status.js
@@ -1,0 +1,7 @@
+const MentorStatus = {
+  UNAVAILABLE: 1,
+  CAN_MENTOR: 2,
+  NEEDS_MENTOR: 3,
+};
+
+module.exports = MentorStatus;

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -1,5 +1,4 @@
 const mongoose = require('mongoose');
-const InterestSchema = require('./interest').InterestSchema;
 
 const Schema = mongoose.Schema;
 
@@ -11,7 +10,7 @@ const UserSchema = Schema({
   email: String,
   thumbnailPath: String,
   interests: [{
-    interest: InterestSchema,
+    interestId: Schema.Types.ObjectId,
     rating: Number,
     status: Number,
   }],

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -1,0 +1,22 @@
+const mongoose = require('mongoose');
+const InterestSchema = require('./interest').InterestSchema;
+
+const Schema = mongoose.Schema;
+
+const UserSchema = Schema({
+  _id: Schema.Types.ObjectId,
+  name: String,
+  description: String,
+  location: String,
+  email: String,
+  thumbnailPath: String,
+  interests: [{
+    interest: InterestSchema,
+    rating: Number,
+    status: Number,
+  }],
+});
+
+const User = mongoose.model('User', UserSchema);
+
+module.exports = User;

--- a/server/services/search-service.js
+++ b/server/services/search-service.js
@@ -7,29 +7,38 @@ const UserCollection = collections.UserCollection;
 
 class SearchService {
   static search(query, callback) {
-    // Search interests for interests that match the query
-    InterestCollection.getInterests({ $text: { $search: query }}, (err, interests) => {
+    const interestQuery = {
+      $or: [
+        { name: { $regex: query, $options: 'i' } },
+        { 'keywords.term': { $regex: query, $options: 'i' } },
+      ],
+    };
+
+    // Search interests for interests that match the user's query
+    InterestCollection.getInterests(interestQuery, (err, interests) => {
       if (err) throw err;
 
       let interestIds = interests.map(i => i._id) || [];
 
-      let userQuery;
-      const textQuery = { $text: { $search: query } };
+      const userQuery = {
+        $or: [
+          { name: { $regex: query, $options: 'i' } },
+          { location: { $regex: query, $options: 'i' } },
+          { email: { $regex: query, $options: 'i' } },
+        ]
+      };
 
       // If any interests match up, OR the results into the query for users
       if (interestIds.length) {
-        userQuery = {
-          $or: [
-            {
-              'interests.interestId': { $in: interestIds },
-            },
-            textQuery,
-          ],
-        };
-      } else {
-        userQuery = textQuery;
+        userQuery.$or.push({
+          'interests.interestId': { $in: interestIds },
+        });
       }
 
+      // TODO: order these results by some priorities:
+      // 1. Interest rating
+      // 2. Number of keywords matched per user
+      // 3. Availability
       UserCollection.getUsers(userQuery, callback);
     });
   }

--- a/server/services/search-service.js
+++ b/server/services/search-service.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const collections = require('../collections');
+
+const InterestCollection = collections.InterestCollection;
+const UserCollection = collections.UserCollection;
+
+class SearchService {
+  static search(query, callback) {
+    // Search interests for interests that match the query
+    InterestCollection.getInterests({ $text: { $search: query }}, (err, interests) => {
+      if (err) throw err;
+
+      let interestIds = interests.map(i => i._id) || [];
+
+      let userQuery;
+      const textQuery = { $text: { $search: query } };
+
+      // If any interests match up, OR the results into the query for users
+      if (interestIds.length) {
+        userQuery = {
+          $or: [
+            {
+              'interests.interestId': { $in: interestIds },
+            },
+            textQuery,
+          ],
+        };
+      } else {
+        userQuery = textQuery;
+      }
+
+      UserCollection.getUsers(userQuery, callback);
+    });
+  }
+}
+
+module.exports = SearchService;


### PR DESCRIPTION
This creates a search API to query against our Mongo database. The API can be reached at `/search?q=<query>`.

For now, it does the following:
- Queries on interests by name and keyword terms
- Queries on users by name, location, and email

It does not do any ordering/prioritization of results. I'll do that in a separate PR, but want to get this out there for people to dev against.
