### PR TITLE
Add an API endpoint for fetching a single user

### DIFF
--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ const read = fs.readFileSync;
 const app = express();
 
 const SearchService = require('./server/services/search-service');
+const UserService = require('./server/services/user-service');
 
 app.use(express.static('views'));
 app.use('/dist', express.static('dist'));
@@ -13,12 +14,19 @@ app.get('/', (req, res) => {
   res.send(read('./views/home.html', 'utf8'));
 });
 
-// TODO: implement search across users and interests
-app.get('/search', (req, res) => {
+app.get('/api/v1/search', (req, res) => {
   SearchService.search(req.query.q, (err, users) => {
     if (err) return console.error(err);
 
     res.send(users);
+  });
+});
+
+app.get('/api/v1/users/:id', (req, res) => {
+  UserService.getUser(req.params.id, (err, user) => {
+    if (err) return console.error(err);
+
+    res.send(user);
   });
 });
 

--- a/server/collections/user-collection.js
+++ b/server/collections/user-collection.js
@@ -7,6 +7,10 @@ class UserCollection {
   static getUsers(query, cb) {
     User.find(query, cb);
   }
+
+  static getUser(query, cb) {
+    User.findOne(query, cb);
+  }
 }
 
 module.exports = UserCollection;

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -13,6 +13,11 @@ const UserSchema = Schema({
     interestId: Schema.Types.ObjectId,
     rating: Number,
     status: Number,
+    name: String,
+    keywords: [{
+      userId: Schema.Types.ObjectId,
+      term: String,
+    }],
   }],
 });
 

--- a/server/services/user-service.js
+++ b/server/services/user-service.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const collections = require('../collections');
+const UserCollection = collections.UserCollection;
+const InterestCollection = collections.InterestCollection;
+
+class UserService {
+  static getUser(userId, callback) {
+    UserCollection.getUser({ _id: userId }, (err, user) => {
+      if (err) throw err;
+
+      const interestIds = user.interests.map(i => i.interestId) || [];
+
+      // If the user has any interests, map those back onto the JSON we return
+      if (interestIds.length) {
+        InterestCollection.getInterests({ _id: { $in: interestIds } }, (err, interests) => {
+          if (err) throw err;
+
+          user.interests = interests;
+          callback(err, user);
+        });
+      } else {
+        callback(err, user);
+      }
+    });
+  }
+}
+
+module.exports = UserService;


### PR DESCRIPTION
This adds a simple API endpoint for fetching a user by their ID, at `/api/v1/users/:id`. It will also fetch any interests for that user and add those to the returned JSON document.

As a side note, this also migrates the search API to `/api/v1/search`.
