### PR TITLE
Add support for creating users

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
+    "body-parser": "^1.15.0",
     "css-loader": "^0.23.1",
     "eslint": "^2.3.0",
     "eslint-loader": "^1.3.0",

--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const bodyParser = require('body-parser');
 const fs = require('fs');
 
 const read = fs.readFileSync;
@@ -6,6 +7,8 @@ const app = express();
 
 const SearchService = require('./server/services/search-service');
 const UserService = require('./server/services/user-service');
+
+app.use(bodyParser.json());
 
 app.use(express.static('views'));
 app.use('/dist', express.static('dist'));
@@ -29,6 +32,43 @@ app.get('/api/v1/users/:id', (req, res) => {
     res.send(user);
   });
 });
+
+app.post('/api/v1/users', (req, res) => {
+  console.log('saving user');
+  console.log(req.body);
+
+  const userInfo = {
+    name: req.body.name,
+    description: req.body.description,
+    location: req.body.location,
+    email: req.body.email,
+    interests: req.body.interests,
+  };
+
+  UserService.createUser(userInfo, (err, user) => {
+    if (err) return console.error(err);
+
+    res.send(user);
+  });
+});
+
+// TODO: implement updating users in a separate PR
+// app.post('/api/v1/users/:id', (req, res) => {
+//   const userInfo = {
+//     _id: req.body._id || req.params.id,
+//     name: req.body.name,
+//     description: req.body.description,
+//     location: req.body.location,
+//     email: req.body.email,
+//     interests: req.body.interests,
+//   };
+//
+//   UserService.updateUser(userInfo, (err, user) => {
+//     if (err) return console.error(err);
+//
+//     res.send(user);
+//   });
+// });
 
 const server = app.listen(process.env.PORT || 5000, () => {
   const host = server.address().address;

--- a/server.js
+++ b/server.js
@@ -34,9 +34,6 @@ app.get('/api/v1/users/:id', (req, res) => {
 });
 
 app.post('/api/v1/users', (req, res) => {
-  console.log('saving user');
-  console.log(req.body);
-
   const userInfo = {
     name: req.body.name,
     description: req.body.description,

--- a/server/collections/interest-collection.js
+++ b/server/collections/interest-collection.js
@@ -7,6 +7,10 @@ class InterestCollection {
   static getInterests(query, cb) {
     Interest.find(query, cb);
   }
+
+  static createInterests(interests, cb) {
+    Interest.create(interests, cb);
+  }
 }
 
 module.exports = InterestCollection;

--- a/server/collections/interest-collection.js
+++ b/server/collections/interest-collection.js
@@ -9,7 +9,23 @@ class InterestCollection {
   }
 
   static createInterests(interests, cb) {
-    Interest.create(interests, cb);
+    const filteredInterests = interests.filter(i => !i._id);
+
+    Interest.create(filteredInterests, (err, docs) => {
+      if (err) {
+        cb(err);
+        return;
+      }
+
+      interests.forEach(interest => {
+        // if the interest was new, populate its _id with the DB result
+        if (!interest._id) {
+          interest._id = docs.find(d => d.name === interest.name)._id;
+        }
+      });
+
+      cb(err, interests);
+    });
   }
 }
 

--- a/server/collections/user-collection.js
+++ b/server/collections/user-collection.js
@@ -11,6 +11,10 @@ class UserCollection {
   static getUser(query, cb) {
     User.findOne(query, cb);
   }
+
+  static createUser(userInfo, cb) {
+    User.create(userInfo, cb);
+  }
 }
 
 module.exports = UserCollection;

--- a/server/models/interest.js
+++ b/server/models/interest.js
@@ -2,7 +2,6 @@ const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
 const InterestSchema = Schema({
-  _id: Schema.Types.ObjectId,
   name: String,
   keywords: [{
     userId: Schema.Types.ObjectId,

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -2,22 +2,24 @@ const mongoose = require('mongoose');
 
 const Schema = mongoose.Schema;
 
+const EmbeddedInterestSchema = Schema({
+  interestId: Schema.Types.ObjectId,
+  rating: Number,
+  status: Number,
+  name: String,
+  keywords: [{
+    userId: Schema.Types.ObjectId,
+    term: String,
+  }],
+}, { _id: false });
+
 const UserSchema = Schema({
   name: String,
   description: String,
   location: String,
   email: String,
   thumbnailPath: String,
-  interests: [{
-    interestId: Schema.Types.ObjectId,
-    rating: Number,
-    status: Number,
-    name: String,
-    keywords: [{
-      userId: Schema.Types.ObjectId,
-      term: String,
-    }],
-  }],
+  interests: [EmbeddedInterestSchema],
 });
 
 const User = mongoose.model('User', UserSchema);

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -3,7 +3,6 @@ const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
 const UserSchema = Schema({
-  _id: Schema.Types.ObjectId,
   name: String,
   description: String,
   location: String,

--- a/server/services/user-service.js
+++ b/server/services/user-service.js
@@ -26,7 +26,6 @@ class UserService {
   }
 
   static createUser(userInfo, callback) {
-    // TODO: handle the case in which the interests already exist
     this._createAllInterests(userInfo.interests, (err, interests) => {
       if (err) {
         callback(err);
@@ -49,6 +48,7 @@ class UserService {
   static _createAllInterests(interests, callback) {
     const trimmedInterests = interests.map(interest => {
       return {
+        _id: interest.interestId,
         name: interest.name,
       };
     });

--- a/server/services/user-service.js
+++ b/server/services/user-service.js
@@ -24,6 +24,37 @@ class UserService {
       }
     });
   }
+
+  static createUser(userInfo, callback) {
+    // TODO: handle the case in which the interests already exist
+    this._createAllInterests(userInfo.interests, (err, interests) => {
+      if (err) {
+        callback(err);
+        return;
+      }
+
+      const userInterests = interests.map((i, index) => {
+        return {
+          interestId: i._id,
+          rating: userInfo.interests[index].rating,
+          status: userInfo.interests[index].status,
+        };
+      });
+
+      userInfo.interests = userInterests;
+      UserCollection.createUser(userInfo, callback);
+    });
+  }
+
+  static _createAllInterests(interests, callback) {
+    const trimmedInterests = interests.map(interest => {
+      return {
+        name: interest.name,
+      };
+    });
+
+    InterestCollection.createInterests(trimmedInterests, callback);
+  }
 }
 
 module.exports = UserService;


### PR DESCRIPTION
This adds support for creating a user in MongoDB by making a request to `POST /api/v1/users`. Currently, keywords for interests are not supported.
