### PR TITLE
Add support for updating user information

### DIFF
--- a/server.js
+++ b/server.js
@@ -49,23 +49,22 @@ app.post('/api/v1/users', (req, res) => {
   });
 });
 
-// TODO: implement updating users in a separate PR
-// app.post('/api/v1/users/:id', (req, res) => {
-//   const userInfo = {
-//     _id: req.body._id || req.params.id,
-//     name: req.body.name,
-//     description: req.body.description,
-//     location: req.body.location,
-//     email: req.body.email,
-//     interests: req.body.interests,
-//   };
-//
-//   UserService.updateUser(userInfo, (err, user) => {
-//     if (err) return console.error(err);
-//
-//     res.send(user);
-//   });
-// });
+app.post('/api/v1/users/:id', (req, res) => {
+  const userInfo = {
+    _id: req.body._id || req.params.id,
+    name: req.body.name,
+    description: req.body.description,
+    location: req.body.location,
+    email: req.body.email,
+    interests: req.body.interests,
+  };
+
+  UserService.updateUser(userInfo, (err, user) => {
+    if (err) return console.error(err);
+
+    res.send(user);
+  });
+});
 
 app.get('/profile/:id', (req, res) => {
   res.send(read('./views/profile.html', 'utf8'));

--- a/server/collections/user-collection.js
+++ b/server/collections/user-collection.js
@@ -15,6 +15,10 @@ class UserCollection {
   static createUser(userInfo, cb) {
     User.create(userInfo, cb);
   }
+
+  static updateUsers(query, update, cb) {
+    User.update(query, update, cb);
+  }
 }
 
 module.exports = UserCollection;

--- a/server/services/user-service.js
+++ b/server/services/user-service.js
@@ -7,7 +7,10 @@ const InterestCollection = collections.InterestCollection;
 class UserService {
   static getUser(userId, callback) {
     UserCollection.getUser({ _id: userId }, (err, user) => {
-      if (err) throw err;
+      if (err) {
+        callback(err);
+        return;
+      }
 
       const interestIds = user.interests.map(i => i.interestId) || [];
 
@@ -45,12 +48,53 @@ class UserService {
     });
   }
 
+  static updateUser(userInfo, callback) {
+    this._createAllInterests(userInfo.interests, (err, interests) => {
+      if (err) {
+        callback(err);
+        return;
+      }
+
+      const userInterests = interests.map((i, index) => {
+        return {
+          interestId: i._id,
+          rating: userInfo.interests[index].rating,
+          status: userInfo.interests[index].status,
+        };
+      });
+
+      const update = {
+        interests: userInterests,
+      };
+
+      if (userInfo.name) {
+        update.name = userInfo.name;
+      }
+      if (userInfo.description) {
+        update.description = userInfo.description;
+      }
+      if (userInfo.location) {
+        update.location = userInfo.location;
+      }
+      if (userInfo.email) {
+        update.email = userInfo.email;
+      }
+
+      UserCollection.updateUsers({ _id: userInfo._id }, update, callback);
+    });
+  }
+
   static _createAllInterests(interests, callback) {
     const trimmedInterests = interests.map(interest => {
-      return {
-        _id: interest.interestId,
+      const newInterest = {
         name: interest.name,
       };
+
+      if (interest.interestId) {
+        newInterest._id = interest.interestId;
+      }
+
+      return newInterest;
     });
 
     InterestCollection.createInterests(trimmedInterests, callback);


### PR DESCRIPTION
This adds an API endpoint for updating user info, at `POST /api/v1/users/:id`. It does not currently support updating keywords on an interest, but does support adding/removing interests, and also supports updating rating and status for each interest.
