### PR TITLE
Refactor schema for MVP

### DIFF
--- a/server/models/interest.js
+++ b/server/models/interest.js
@@ -3,10 +3,6 @@ const Schema = mongoose.Schema;
 
 const InterestSchema = Schema({
   name: String,
-  keywords: [{
-    userId: Schema.Types.ObjectId,
-    term: String,
-  }],
 });
 
 const Interest = mongoose.model('Interest', InterestSchema);

--- a/server/models/mentor-status.js
+++ b/server/models/mentor-status.js
@@ -1,7 +1,0 @@
-const MentorStatus = {
-  UNAVAILABLE: 1,
-  CAN_MENTOR: 2,
-  NEEDS_MENTOR: 3,
-};
-
-module.exports = MentorStatus;

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -4,13 +4,10 @@ const Schema = mongoose.Schema;
 
 const EmbeddedInterestSchema = Schema({
   interestId: Schema.Types.ObjectId,
-  rating: Number,
-  status: Number,
   name: String,
-  keywords: [{
-    userId: Schema.Types.ObjectId,
-    term: String,
-  }],
+  rating: Number,
+  canMentor: Boolean,
+  needsMentor: Boolean,
 }, { _id: false });
 
 const UserSchema = Schema({
@@ -18,7 +15,6 @@ const UserSchema = Schema({
   description: String,
   location: String,
   email: String,
-  thumbnailPath: String,
   interests: [EmbeddedInterestSchema],
 });
 

--- a/server/services/user-service.js
+++ b/server/services/user-service.js
@@ -19,7 +19,7 @@ class UserService {
         InterestCollection.getInterests({ _id: { $in: interestIds } }, (err, interests) => {
           if (err) throw err;
 
-          user.interests = interests;
+          user.interests = this._toUserInterests(interests, user.interests);
           callback(err, user);
         });
       } else {
@@ -35,15 +35,7 @@ class UserService {
         return;
       }
 
-      const userInterests = interests.map((i, index) => {
-        return {
-          interestId: i._id,
-          rating: userInfo.interests[index].rating,
-          status: userInfo.interests[index].status,
-        };
-      });
-
-      userInfo.interests = userInterests;
+      userInfo.interests = this._toUserInterests(interests, userInfo.interests);
       UserCollection.createUser(userInfo, callback);
     });
   }
@@ -55,16 +47,8 @@ class UserService {
         return;
       }
 
-      const userInterests = interests.map((i, index) => {
-        return {
-          interestId: i._id,
-          rating: userInfo.interests[index].rating,
-          status: userInfo.interests[index].status,
-        };
-      });
-
       const update = {
-        interests: userInterests,
+        interests: this._toUserInterests(interests, userInfo.interests),
       };
 
       if (userInfo.name) {
@@ -81,6 +65,17 @@ class UserService {
       }
 
       UserCollection.updateUsers({ _id: userInfo._id }, update, callback);
+    });
+  }
+
+  static _toUserInterests(interests, userInterests) {
+    return interests.map((i, index) => {
+      return {
+        interestId: i._id,
+        rating: userInterests[index].rating,
+        canMentor: userInterests[index].canMentor,
+        needsMentor: userInterests[index].needsMentor,
+      };
     });
   }
 


### PR DESCRIPTION
Includes the following changes:
- Splits out `status` into `canMentor` and `needsMentor` fields
- Removes `keywords`
- Removes `MentorStatus` enum
- Properly inflates search results with interest data (mainly, the interest names)
