### PR TITLE
Return existing user with email on POST if possible

### DIFF
--- a/server/services/user-service.js
+++ b/server/services/user-service.js
@@ -29,14 +29,22 @@ class UserService {
   }
 
   static createUser(userInfo, callback) {
-    this._createAllInterests(userInfo.interests, (err, interests) => {
-      if (err) {
-        callback(err);
+    // check if a user exists with the specified email, and if so, return that document
+    UserCollection.getUser({ email: userInfo.email }, (err, user) => {
+      if (user) {
+        callback(err, user);
         return;
       }
 
-      userInfo.interests = this._toUserInterests(interests, userInfo.interests);
-      UserCollection.createUser(userInfo, callback);
+      this._createAllInterests(userInfo.interests, (err, interests) => {
+        if (err) {
+          callback(err);
+          return;
+        }
+
+        userInfo.interests = this._toUserInterests(interests, userInfo.interests);
+        UserCollection.createUser(userInfo, callback);
+      });
     });
   }
 


### PR DESCRIPTION
When we're sending a `POST` to `/api/v1/users`, we want to check if a user with that email exists and, if so, return that document rather than what was posted. This branch allows that.
